### PR TITLE
Add basic ControlNode test

### DIFF
--- a/src/pick_place_demo/CMakeLists.txt
+++ b/src/pick_place_demo/CMakeLists.txt
@@ -105,4 +105,14 @@ install(
   DESTINATION include
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(test_control_node
+    test/test_control_node.cpp
+  )
+  target_link_libraries(test_control_node control_node)
+endif()
+
 ament_package()

--- a/src/pick_place_demo/include/pick_place_demo/control_node.hpp
+++ b/src/pick_place_demo/include/pick_place_demo/control_node.hpp
@@ -29,6 +29,8 @@ public:
   explicit ControlNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
   virtual ~ControlNode() = default;
 
+  RobotState get_current_state() const { return current_state_; }
+
 private:
   void target_pose_callback(const geometry_msgs::msg::PoseStamped::SharedPtr msg);
   void timer_callback();

--- a/src/pick_place_demo/test/test_control_node.cpp
+++ b/src/pick_place_demo/test/test_control_node.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+
+#include "pick_place_demo/control_node.hpp"
+
+using namespace std::chrono_literals;
+
+TEST(ControlNodeTest, TargetPoseAdvancesState)
+{
+  rclcpp::init(0, nullptr);
+  auto test_clock = std::make_shared<rclcpp::TestClock>();
+  rclcpp::NodeOptions options;
+  options.clock(test_clock);
+  auto node = std::make_shared<pick_place_demo::ControlNode>(options);
+
+  auto executor = rclcpp::executors::SingleThreadedExecutor::make_shared();
+  executor->add_node(node);
+
+  auto pub = node->create_publisher<geometry_msgs::msg::PoseStamped>("target_pose", 10);
+
+  geometry_msgs::msg::PoseStamped msg;
+  msg.header.frame_id = "world";
+  msg.pose.orientation.w = 1.0;
+
+  EXPECT_EQ(node->get_current_state(), pick_place_demo::RobotState::IDLE);
+
+  executor->spin_some();
+  pub->publish(msg);
+
+  for (int i = 0; i < 5; ++i) {
+    executor->spin_some();
+    rclcpp::sleep_for(100ms);
+  }
+
+  EXPECT_EQ(node->get_current_state(), pick_place_demo::RobotState::PLANNING);
+
+  rclcpp::shutdown();
+}
+


### PR DESCRIPTION
## Summary
- expose ControlNode state for testing
- add gtest to verify state change when a target pose is published
- enable building the test via ament_add_gtest and ament_lint_auto

## Testing
- `colcon build` *(fails: could not find ROS dependencies)*
- `colcon test --packages-select pick_place_demo` *(fails: package was not built)*


------
https://chatgpt.com/codex/tasks/task_e_6840150d3d988331af877ded8f947878