### PR TITLE
Add clang-format and ament formatting tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+BasedOnStyle: LLVM
+IndentWidth: 2
+ColumnLimit: 120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v20.1.5
+    hooks:
+      - id: clang-format
+        files: \.(cpp|hpp|c|h)$
+        args: ['-style=file']

--- a/src/cell_description/CMakeLists.txt
+++ b/src/cell_description/CMakeLists.txt
@@ -15,3 +15,10 @@ install(
 )
 
 ament_package()
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_clang_format REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  ament_clang_format()
+endif()

--- a/src/cell_gui/CMakeLists.txt
+++ b/src/cell_gui/CMakeLists.txt
@@ -72,3 +72,10 @@ install(
 )
 
 ament_package()
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_clang_format REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  ament_clang_format()
+endif()

--- a/src/pick_place_demo/CMakeLists.txt
+++ b/src/pick_place_demo/CMakeLists.txt
@@ -107,7 +107,9 @@ install(
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_clang_format REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  ament_clang_format()
 
   ament_add_gtest(test_control_node
     test/test_control_node.cpp


### PR DESCRIPTION
## Summary
- add LLVM-based `.clang-format`
- configure clang-format checks in CMake when BUILD_TESTING is enabled
- provide a simple pre-commit config for clang-format

## Testing
- `pre-commit run --files src/cell_description/CMakeLists.txt src/cell_gui/CMakeLists.txt src/pick_place_demo/CMakeLists.txt`

------
https://chatgpt.com/codex/tasks/task_e_68401a0474d483318df47b8ff8321211