### PR TITLE
Add CI workflow for ROS 2 Humble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup ROS 2
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: humble
+
+      - name: Install dependencies
+        run: |
+          sudo rosdep init || true
+          rosdep update
+          rosdep install --from-paths src --rosdistro humble -y --ignore-src
+          sudo apt-get update
+          sudo apt-get install -y ros-humble-ament-lint-auto
+
+      - name: Build
+        run: |
+          source /opt/ros/humble/setup.bash
+          colcon build --event-handlers console_cohesion+
+
+      - name: Test
+        run: |
+          source install/setup.bash
+          colcon test


### PR DESCRIPTION
## Summary
- set up GitHub Actions CI workflow
- install ROS 2 Humble and dependencies
- build using `colcon` with console cohesion and run tests

## Testing
- `rosdep install --from-paths src --rosdistro humble -y --ignore-src` *(fails: no definition of several packages for OS version noble)*
- `colcon build --event-handlers console_cohesion+` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_684019e4b5b08331b95aa7de729cfa6d