### PR TITLE
Add additional tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ros-tooling/setup-ros@v0.2
+        with:
+          required-ros-distributions: humble
+      - name: Install dependencies
+        run: sudo apt-get update
+      - name: Run tests
+        run: |
+          source /opt/ros/humble/setup.bash
+          colcon test --event-handlers console_cohesion+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: build/**/test_results/**/*.xml

--- a/src/pick_place_demo/CMakeLists.txt
+++ b/src/pick_place_demo/CMakeLists.txt
@@ -113,6 +113,16 @@ if(BUILD_TESTING)
     test/test_control_node.cpp
   )
   target_link_libraries(test_control_node control_node)
+
+  ament_add_gtest(test_control_node_states
+    test/test_control_node_states.cpp
+  )
+  target_link_libraries(test_control_node_states control_node)
+
+  ament_add_gtest(test_vision_node
+    test/test_vision_node.cpp
+  )
+  target_link_libraries(test_vision_node vision_node)
 endif()
 
 ament_package()

--- a/src/pick_place_demo/include/pick_place_demo/control_node.hpp
+++ b/src/pick_place_demo/include/pick_place_demo/control_node.hpp
@@ -12,6 +12,8 @@
 namespace pick_place_demo
 {
 
+class ControlNodeTestHelper;  // forward declaration for tests
+
 enum class RobotState
 {
   IDLE,
@@ -76,6 +78,9 @@ private:
   double pick_approach_distance_;
   double place_retreat_distance_;
   std::string gripper_type_;
+
+  // Allow tests to access private members
+  friend class ::pick_place_demo::ControlNodeTestHelper;
 };
 
 }  // namespace pick_place_demo

--- a/src/pick_place_demo/test/test_control_node_states.cpp
+++ b/src/pick_place_demo/test/test_control_node_states.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include "pick_place_demo/control_node.hpp"
+
+namespace pick_place_demo {
+class ControlNodeTestHelper {
+public:
+  static void setState(ControlNode & node, RobotState state) { node.current_state_ = state; }
+  static void setGraspSuccess(ControlNode & node, bool success) { node.grasp_success_ = success; }
+  static void runStateMachine(ControlNode & node) { node.execute_state_machine(); }
+};
+}
+
+using namespace std::chrono_literals;
+
+TEST(ControlNodeStates, GraspFailureReturnsIdle)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<pick_place_demo::ControlNode>();
+  pick_place_demo::ControlNodeTestHelper::setState(*node, pick_place_demo::RobotState::GRASPING);
+  pick_place_demo::ControlNodeTestHelper::setGraspSuccess(*node, false);
+  pick_place_demo::ControlNodeTestHelper::runStateMachine(*node);
+  EXPECT_EQ(node->get_current_state(), pick_place_demo::RobotState::IDLE);
+  rclcpp::shutdown();
+}
+
+TEST(ControlNodeStates, MoveHomeCompletesCycle)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<pick_place_demo::ControlNode>();
+  pick_place_demo::ControlNodeTestHelper::setState(*node, pick_place_demo::RobotState::MOVING_TO_HOME);
+  pick_place_demo::ControlNodeTestHelper::runStateMachine(*node);
+  EXPECT_EQ(node->get_current_state(), pick_place_demo::RobotState::IDLE);
+  rclcpp::shutdown();
+}
+

--- a/src/pick_place_demo/test/test_vision_node.cpp
+++ b/src/pick_place_demo/test/test_vision_node.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <vision_msgs/msg/detection3_d_array.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/opencv.hpp>
+
+#include "pick_place_demo/vision_node.hpp"
+
+class TestableVisionNode : public pick_place_demo::VisionNode
+{
+public:
+  using pick_place_demo::VisionNode::VisionNode;
+
+  void setCameraInfo(const sensor_msgs::msg::CameraInfo::SharedPtr & msg)
+  {
+    camera_info_callback(msg);
+  }
+
+  void runDetection(const sensor_msgs::msg::Image::SharedPtr & rgb,
+                    const sensor_msgs::msg::Image::SharedPtr & depth,
+                    vision_msgs::msg::Detection3DArray & output)
+  {
+    detect_objects(rgb, depth, output);
+  }
+
+  bool transformPose(const geometry_msgs::msg::PoseStamped & in,
+                     geometry_msgs::msg::PoseStamped & out)
+  {
+    return transform_to_world_frame(in, out);
+  }
+
+  void addTransform(const geometry_msgs::msg::TransformStamped & t)
+  {
+    tf_buffer_->setTransform(t, "test");
+  }
+};
+
+TEST(VisionNodeTest, DetectsRedObject)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<TestableVisionNode>();
+
+  auto info = std::make_shared<sensor_msgs::msg::CameraInfo>();
+  info->k = {100.0, 0.0, 320.0,
+             0.0, 100.0, 240.0,
+             0.0, 0.0, 1.0};
+  node->setCameraInfo(info);
+
+  cv::Mat rgb(480, 640, CV_8UC3, cv::Scalar(0, 0, 0));
+  cv::rectangle(rgb, cv::Point(200, 200), cv::Point(300, 300), cv::Scalar(0, 0, 255), -1);
+  auto rgb_msg = cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", rgb).toImageMsg();
+
+  cv::Mat depth(480, 640, CV_16UC1, cv::Scalar(1000));
+  auto depth_msg = cv_bridge::CvImage(std_msgs::msg::Header(), sensor_msgs::image_encodings::TYPE_16UC1, depth).toImageMsg();
+
+  vision_msgs::msg::Detection3DArray detections;
+  node->runDetection(rgb_msg, depth_msg, detections);
+
+  EXPECT_GT(detections.detections.size(), 0u);
+  rclcpp::shutdown();
+}
+
+TEST(VisionNodeTest, TransformPose)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<TestableVisionNode>();
+
+  geometry_msgs::msg::TransformStamped t;
+  t.header.frame_id = "camera_color_optical_frame";
+  t.child_frame_id = "world";
+  t.transform.rotation.w = 1.0;
+  node->addTransform(t);
+
+  geometry_msgs::msg::PoseStamped in, out;
+  in.header.frame_id = "camera_color_optical_frame";
+  in.pose.orientation.w = 1.0;
+
+  EXPECT_TRUE(node->transformPose(in, out));
+  EXPECT_EQ(out.header.frame_id, "world");
+  rclcpp::shutdown();
+}
+


### PR DESCRIPTION
## Summary
- extend `ControlNode` API for tests
- add new tests covering grasp failure and move-to-home logic
- add tests for object detection and TF transforms in `VisionNode`
- enable running all tests in CI

## Testing
- `colcon test --packages-select pick_place_demo --event-handlers console_cohesion+ --return-code-on-test-failure` *(fails: colcon not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401a0dc6548331841a69d47027664b