### PR TITLE
Handle process errors in Qt GUI

### DIFF
--- a/src/cell_gui/include/cell_gui/main_window.hpp
+++ b/src/cell_gui/include/cell_gui/main_window.hpp
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QProcess>
+#include <QTimer>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/string.hpp>
@@ -37,6 +38,9 @@ private slots:
   void updateSystemStatus(const QString& status);
   void updateCycleTime(double time);
   void updateSuccessRate(double rate);
+
+  void processFinished(const QString& name, int exitCode, QProcess::ExitStatus status);
+  void processError(const QString& name, QProcess::ProcessError error);
   
 private:
   void initROS();


### PR DESCRIPTION
## Summary
- hook into `errorOccurred` and `finished` for simulation and demo processes
- log failures and display a message box when a process exits non‑zero
- use helper methods to update buttons and system status

## Testing
- `colcon test --packages-select cell_gui` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68401a31f71c8331b36ece3d9e7bc025