### PR TITLE
Fix pick_place_demo executor lifetime issue

### DIFF
--- a/src/pick_place_demo/src/control_node.cpp
+++ b/src/pick_place_demo/src/control_node.cpp
@@ -28,13 +28,7 @@ ControlNode::ControlNode(const rclcpp::NodeOptions & options)
   place_pose_.pose.orientation.w = 1.0;
   
   // Initialize MoveIt interfaces
-  // We need to do this after the node is fully initialized
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(this->get_node_base_interface());
-  
-  std::thread([&executor]() {
-    executor.spin();
-  }).detach();
+  // MoveGroupInterface will be serviced by the main executor
   
   move_group_ = std::make_shared<moveit::planning_interface::MoveGroupInterface>(
     shared_from_this(), arm_group_name_);


### PR DESCRIPTION
## Summary
- remove local executor thread from `ControlNode`

The local executor was created on the stack and spun in a detached thread. Once
construction finished, the executor object was destroyed while the thread kept
running, leading to undefined behaviour. MoveGroupInterface will now rely on the
main executor started in `control_node_main.cpp`.

## Testing
- `colcon build --packages-select pick_place_demo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684011ce7bdc833192552ce383552efd