### PR TITLE
Add QThread and cstdlib includes

### DIFF
--- a/src/cell_gui/src/main_window.cpp
+++ b/src/cell_gui/src/main_window.cpp
@@ -6,7 +6,9 @@
 #include <QSettings>
 #include <QTimer>
 #include <QProcess>
+#include <QThread>
 #include <QDebug>
+#include <cstdlib>
 #include <fstream>
 
 namespace cell_gui


### PR DESCRIPTION
## Summary
- include `<QThread>` and `<cstdlib>` in `main_window.cpp`

## Testing
- `g++ -std=c++17 -I src/cell_gui/include -c src/cell_gui/src/main_window.cpp -o /tmp/main_window.o` *(fails: `QMainWindow` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684024669b348331bd33f04f6818c2a2