### PR TITLE
Add ROS shutdown to GUI destructor

### DIFF
--- a/src/cell_gui/src/main_window.cpp
+++ b/src/cell_gui/src/main_window.cpp
@@ -77,7 +77,10 @@ MainWindow::~MainWindow()
   
   // Save settings
   saveSettings();
-  
+
+  // Shutdown ROS
+  rclcpp::shutdown();
+
   // Clean up
   delete ui;
 }


### PR DESCRIPTION
## Summary
- ensure GUI shuts down ROS when closing

## Testing
- `pre-commit run --files src/cell_gui/src/main_window.cpp` *(fails: files modified by hook)*

------
https://chatgpt.com/codex/tasks/task_e_6840246d845083318018accb7701f198