### PR TITLE
Fix executor creation in control node test

### DIFF
--- a/src/pick_place_demo/test/test_control_node.cpp
+++ b/src/pick_place_demo/test/test_control_node.cpp
@@ -14,7 +14,7 @@ TEST(ControlNodeTest, TargetPoseAdvancesState)
   options.clock(test_clock);
   auto node = std::make_shared<pick_place_demo::ControlNode>(options);
 
-  auto executor = rclcpp::executors::SingleThreadedExecutor::make_shared();
+  auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
   executor->add_node(node);
 
   auto pub = node->create_publisher<geometry_msgs::msg::PoseStamped>("target_pose", 10);


### PR DESCRIPTION
## Summary
- fix use of `std::make_shared` for creating executor in unit test

## Testing
- `colcon build --packages-select pick_place_demo` *(fails: Failed to find the following files)*

------
https://chatgpt.com/codex/tasks/task_e_684024711a0483318d2b3f41bf97fb3c