### PR TITLE
Add Qt resource icons

### DIFF
--- a/src/cell_gui/CMakeLists.txt
+++ b/src/cell_gui/CMakeLists.txt
@@ -28,10 +28,15 @@ set(UI_FILES
 qt5_wrap_ui(UI_HEADERS ${UI_FILES})
 
 # Add executable
+set(RESOURCE_FILES
+  resources/icons.qrc
+)
+
 add_executable(cell_gui_node
   src/main.cpp
   src/main_window.cpp
   ${UI_HEADERS}
+  ${RESOURCE_FILES}
 )
 
 # Add dependencies

--- a/src/cell_gui/resources/icons.qrc
+++ b/src/cell_gui/resources/icons.qrc
@@ -1,0 +1,8 @@
+<RCC>
+    <qresource prefix="/icons">
+        <file>start.svg</file>
+        <file>stop.svg</file>
+        <file>save.svg</file>
+        <file>open.svg</file>
+    </qresource>
+</RCC>

--- a/src/cell_gui/resources/open.svg
+++ b/src/cell_gui/resources/open.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/><line x1="12" y1="11" x2="12" y2="17"/><line x1="9" y1="14" x2="15" y2="14"/></svg>

--- a/src/cell_gui/resources/save.svg
+++ b/src/cell_gui/resources/save.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>

--- a/src/cell_gui/resources/start.svg
+++ b/src/cell_gui/resources/start.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>

--- a/src/cell_gui/resources/stop.svg
+++ b/src/cell_gui/resources/stop.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><rect x="9" y="9" width="6" height="6"/></svg>


### PR DESCRIPTION
## Summary
- add Start/Stop icons to new `resources` folder
- generate Qt resources from icons

## Testing
- `colcon build --symlink-install` *(fails: ament_cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402b78813c83319015533df36df2a8