### PR TITLE
Add traveled distance metric

### DIFF
--- a/src/pick_place_demo/include/pick_place_demo/control_node.hpp
+++ b/src/pick_place_demo/include/pick_place_demo/control_node.hpp
@@ -9,6 +9,8 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <cmath>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
 
 namespace pick_place_demo
 {
@@ -39,6 +41,7 @@ private:
   void timer_callback();
   bool enable_suction(bool enable);
   void log_cycle_data();
+  double compute_path_length(const moveit::planning_interface::MoveGroupInterface::Plan & plan);
   void execute_state_machine();
 
   // MoveIt interfaces


### PR DESCRIPTION
## Summary
- compute traveled distance from executed plans by summing joint motion between trajectory points
- accumulate traveled distance for every robot movement
- log traveled distance in cycle metrics and overall summary

## Testing
- `colcon test --packages-select pick_place_demo --return-code-on-test-failure` *(fails: command not found)*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_68402ba821908331bb578412aecbd255