### PR TITLE
Link OpenCV explicitly in vision node

### DIFF
--- a/src/pick_place_demo/CMakeLists.txt
+++ b/src/pick_place_demo/CMakeLists.txt
@@ -40,8 +40,8 @@ ament_target_dependencies(vision_node
   tf2_geometry_msgs
   cv_bridge
   message_filters
-  OpenCV
 )
+target_link_libraries(vision_node ${OpenCV_LIBRARIES})
 rclcpp_components_register_nodes(vision_node
   "pick_place_demo::VisionNode"
 )


### PR DESCRIPTION
## Summary
- link OpenCV manually in `vision_node`

## Testing
- `colcon build` *(fails: could not find ROS packages)*
- `colcon test --event-handlers console_cohesion+` *(fails: packages were not built)*

------
https://chatgpt.com/codex/tasks/task_e_6840534e1b18833192cbe7c3bb851766