### PR TITLE
Remove unsupported TestClock from test

### DIFF
--- a/src/pick_place_demo/test/test_control_node.cpp
+++ b/src/pick_place_demo/test/test_control_node.cpp
@@ -10,10 +10,7 @@ using namespace std::chrono_literals;
 TEST(ControlNodeTest, TargetPoseAdvancesState)
 {
   rclcpp::init(0, nullptr);
-  auto test_clock = std::make_shared<rclcpp::TestClock>();
-  rclcpp::NodeOptions options;
-  options.clock(test_clock);
-  auto node = std::make_shared<pick_place_demo::ControlNode>(options);
+  auto node = std::make_shared<pick_place_demo::ControlNode>();
 
   auto executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
   executor->add_node(node);


### PR DESCRIPTION
## Summary
- remove custom `rclcpp::TestClock` from control node test

## Testing
- `colcon build --event-handlers console_cohesion+` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6840536306a48331983d556b0b9548bb