### PR TITLE
Pin GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ros-tooling/setup-ros@v0.2
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+      - uses: ros-tooling/setup-ros@cf741628ddbaf279f8cca1b208312bf25ae0e4b4
         with:
           required-ros-distributions: humble
       - name: Install dependencies
@@ -21,7 +21,7 @@ jobs:
           colcon test --event-handlers console_cohesion+
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5
         with:
           name: test-results
           path: build/**/test_results/**/*.xml


### PR DESCRIPTION
## Summary
- pin CI actions to specific commits

## Testing
- `colcon test --event-handlers console_cohesion+` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405583fa2883319738fef9adfdebbd